### PR TITLE
Fix docker-compose error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: neo4j
     volumes:
       - $HOME/neo4j/data:/data
-      - $HOME/neo4j/logs:/logs
     ports:
       - 7474:7474
       - 7687:7687


### PR DESCRIPTION
ERROR: yaml.parser.ParserError: while parsing a block mapping
  in "./docker-compose.yml", line 4, column 3
expected <block end>, but found '<block mapping start>'
  in "./docker-compose.yml", line 15, column 4